### PR TITLE
Added UART command functions to the program

### DIFF
--- a/cg2271.c
+++ b/cg2271.c
@@ -199,3 +199,41 @@ void runMotor(uint8_t direction)
 			break;
 	}
 }
+
+/*
+* Enables UART1 to receive messages at the specified baudrate at PTE1.
+*
+* @param baudrate the baudrate of the UART messages to be received.
+*/
+void init_UART1(uint32_t baudrate)
+{
+	// Enable clock signal to UART1 and PORTC (UART TX/RX pins)
+	SIM -> SCGC4  |= SIM_SCGC4_UART1_MASK;
+	SIM -> SCGC5 |= SIM_SCGC5_PORTE_MASK;
+	
+	// Disable UART1
+	UART1 -> C2 &= ~(UART_C2_TE_MASK);
+	UART1 -> C2 &= ~(UART_C2_RE_MASK);
+	
+	// Clear all previous settings
+	UART1 -> S2 = 0;
+	UART1 -> C1 = 0;
+	UART1 -> C3 = 0;
+	
+	// Set up pins PTE1 for UART RX
+	PORTE -> PCR[1] |= PORT_PCR_MUX(3);
+	
+	// Set baudrate
+	uint32_t bus_clock = DEFAULT_SYSTEM_CLOCK / 2;
+	uint32_t divisor = bus_clock / (baudrate * 16);
+	UART1 -> BDH = UART_BDH_SBR(divisor >> 8);
+	UART1 -> BDL = UART_BDL_SBR(divisor);
+
+	// Enable TX/RX interrupts
+	UART1 -> C2 |= UART_C2_RIE_MASK;
+	NVIC_ClearPendingIRQ(UART1_IRQn);
+	NVIC_EnableIRQ(UART1_IRQn);
+	
+	// Enable RX on UART1
+	UART1 -> C2 |= UART_C2_RE_MASK;
+}

--- a/cg2271.h
+++ b/cg2271.h
@@ -15,4 +15,7 @@ void flashGreenLED(uint32_t index);
 void initMotors(void);
 void runMotor(uint8_t direction);
 
+// UART functions
+void init_UART1(uint32_t baudrate);
+
 #endif

--- a/main.c
+++ b/main.c
@@ -6,10 +6,18 @@
 #include "cg2271.h"
 #include "cmsis_os2.h"
 
+#define QUEUE_SIZE 16 // Macro for queue size - will use 16 bytes (for now)
+#define BAUD_RATE 9600 // Baudrate for UART (for connection to ESP32)
+
 static volatile uint32_t runningLED = 0;
 static volatile uint32_t redBlinkInterval = 250;
 static volatile uint8_t motorDirection = 0;
 
+// Message queue ids
+osMessageQueueId_t command_MsgQueue; // Queue for commands from UART
+osMessageQueueId_t motorDirection_MsgQueue; // Queue for the motor direction
+
+// Thread parameters
 const osThreadAttr_t thread1_attr = {
 	.priority = osPriorityHigh
 };
@@ -17,6 +25,48 @@ const osThreadAttr_t thread1_attr = {
 const osThreadAttr_t thread2_attr = {
 	.priority = osPriorityNormal
 };
+
+// UART ISR
+void UART1_IRQHandler(void)
+{
+	NVIC_ClearPendingIRQ(UART1_IRQn);
+	if (UART1_S1 & UART_S1_RDRF_MASK)
+	{
+		uint8_t command = UART1 -> D;
+		osMessageQueuePut(command_MsgQueue, &command, 0U, 0U);
+	}
+}
+
+/*----------------------------------------------------------------------------
+ * Thread for decoding command (brain thread)
+ *---------------------------------------------------------------------------*/
+__NO_RETURN static void brain_thread(void *argument) {
+  (void)argument;
+  for (;;) {
+		// Get command from command queue
+		uint8_t command;
+		osStatus_t command_status = osMessageQueueGet(command_MsgQueue, &command, NULL, 0U);
+		
+		if (command_status == osOK)
+		{
+			if (command & 0x10)
+			{
+				uint8_t motorDirection = command & 0x0F; // set motorDirection to the last 4 bits of the command
+				osMessageQueuePut(motorDirection_MsgQueue, &motorDirection, 0U, 0U);
+			}
+			else
+			{
+				uint8_t motorDirection = 0x00; // set motorDirection to 0 (stop motors)
+				osMessageQueuePut(motorDirection_MsgQueue, &motorDirection, 0U, 0U);				
+			}
+		}
+		else
+		{
+			uint8_t motorDirection = 0x00; // set motorDirection to 0 (stop motors)
+			osMessageQueuePut(motorDirection_MsgQueue, &motorDirection, 0U, 0U);
+		}
+	}
+}
 
 /*----------------------------------------------------------------------------
  * Thread for blinking green LED
@@ -36,19 +86,33 @@ __NO_RETURN static void led_green_thread(void *argument) {
 __NO_RETURN static void motor_thread(void *argument) {
   (void)argument;
   for (;;) {
-		motorDirection = (motorDirection == 8) ? 0 : (motorDirection + 1);
-		runMotor(motorDirection);
+		uint8_t motorDirection;
+		osStatus_t messageStatus = osMessageQueueGet(motorDirection_MsgQueue, &motorDirection, NULL, 0U);
+		if (messageStatus == osOK)
+		{
+			runMotor(motorDirection);
+		}
+		else
+		{
+			// Motors stationary if no specified direction received
+			runMotor(0x00);
+		}
 		osDelay(2000);
 	}
 }
 
-int main (void) {
+int main(void) {
  
   // System Initialization
   SystemCoreClockUpdate();
   setupGreenLED();
 	initMotors();
- 
+	init_UART1(BAUD_RATE);
+	
+	// Initalize message queues
+	command_MsgQueue = osMessageQueueNew(QUEUE_SIZE, sizeof(uint8_t), NULL); 
+	motorDirection_MsgQueue = osMessageQueueNew(QUEUE_SIZE, sizeof(uint8_t), NULL);
+	
   osKernelInitialize();                 // Initialize CMSIS-RTOS
 	osThreadNew(led_green_thread, NULL, &thread1_attr); // Create thread for green LED
   osThreadNew(motor_thread, NULL, &thread2_attr);     // Create thread for motor


### PR DESCRIPTION
This PR comprises the addition of functions to set up and handle UART communications, and message queues/event flags for communication between threads

## UART communications

The UART communication for the program is set up on UART1, using PTE0 as the RX pin. As described in the project requirements, the communication works through interrupts, with the UART1 ISR pushing the received command into a command message queue.

The UART code is currently not set up to handle errors.

## Communication between threads

Subsequently, the brain thread ```brain_thread``` gets the command from the command message queue ```command_MsgQueue```. Using the command value received, the thread does the following:

* Sends a message (in the form of an unsigned 8-bit integer) to the motor thread, which is used to determine how the motor moves, based on the 4 rightmost bits of the command value.
* Sets the event flags for the green and red LEDs ```greenLEDFlags``` and ```redLEDFlags``` based on the 4 leftmost bits of the command value.