### PR TITLE
Add threads to control red LEDS and buzzer

### DIFF
--- a/cg2271.c
+++ b/cg2271.c
@@ -157,6 +157,41 @@ void flashGreenLED(uint32_t index)
 	}
 }
 
+// Red LED control functions
+
+/*
+* Setup the red LEDs
+*/
+void setupRedLED(void)
+{
+	// Enable clock signal to PORTD and PORTE
+	SIM -> SCGC5 |= SIM_SCGC5_PORTD_MASK;
+	SIM -> SCGC5 |= SIM_SCGC5_PORTE_MASK;
+	
+	// Set up PTE1, PTE0, PTD6, PTD7 as GPIO
+	PORTE -> PCR[0] |= PORT_PCR_MUX(1);
+	PORTE -> PCR[1] |= PORT_PCR_MUX(1);	
+	PORTD -> PCR[6] |= PORT_PCR_MUX(1);
+	PORTD -> PCR[7] |= PORT_PCR_MUX(1);
+	
+	// Configure direction of pins
+	PTE -> PDDR |= (1 << 0);
+	PTE -> PDDR |= (1 << 1);
+	PTD -> PDDR |= (1 << 6);
+	PTD -> PDDR |= (1 << 7);
+}
+
+/*
+* Toggles the red LEDs (switches them ON when they are OFF, and vice versa)
+*/
+void toggleRedLED(void)
+{
+	PTE -> PTOR |= (1 << 0);
+	PTE -> PTOR |= (1 << 1);
+	PTD -> PTOR |= (1 << 6);
+	PTD -> PTOR |= (1 << 7);
+}
+
 // Motor control functions
 
 /*

--- a/cg2271.h
+++ b/cg2271.h
@@ -11,6 +11,10 @@
 void setupGreenLED(void);
 void flashGreenLED(uint32_t index);
 
+// Red LED control functions
+void setupRedLED(void);
+void toggleRedLED(void);
+
 // Motor control functions
 void initMotors(void);
 void runMotor(uint8_t direction);

--- a/cg2271_project.uvoptx
+++ b/cg2271_project.uvoptx
@@ -148,24 +148,7 @@
           <Name>UL2CM3(-S0 -C0 -P0 -FD1FFFF000 -FC4000 -FN1 -FF0MK_P128_48MHZ -FS00 -FL020000 -FP0($$Device:MKL25Z128xxx4$Flash\MK_P128_48MHZ.FLM))</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>60</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>.\cg2271.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <WatchWindow1>
         <Ww>
           <count>0</count>

--- a/main.c
+++ b/main.c
@@ -181,7 +181,7 @@ __NO_RETURN static void motor_thread(void *argument) {
 __NO_RETURN static void buzzer_thread(void *argument) {
   (void)argument;
   for (;;) {
-		mod_index = (mod_index == tune_len) ? 0 : (mod_index + 1);
+		mod_index = (mod_index < tune_len) ? (mod_index + 1) : 0;
 		playBuzzer(tune_mods[mod_index]);
 		osDelay(300);
 	}


### PR DESCRIPTION
This PR adds functionality to control the red LEDs at the rear and the buzzer.

## Red LEDs

The red LEDs controlled are connected to PTE0, PTE1, PTD6 and PTD7 on the FRDM-KL25Z board (order doesn't matter). The thread has the LEDs blinking with a 500ms period when stationary, and a 1000ms period when moving, as per the project requirements.

Each GPIO pin (for this case) is driving 2 LEDs (on the breadboard), so additional testing is needed to verify if the circuit setup works as desired (i.e. if there is sufficient current to drive both LEDs with one GPIO pin).

## Buzzer

The buzzer is connected to PTA12 on the FRDM-KL25Z board. This pin is set up as an edge-aligned PWM output pin from TPM1. The buzzer plays a tune while the robot is either moving or stationary, which can be set by amending the `tune_mods` array in `main.c`. 

When changing `tune_mods`, one must make sure that the `tune_len` value is correctly set to the length of the updated array to avert undesirable memory accesses.

As of the moment, the additional tune for ending the run has not be implemented. It will be implemented subsequently in its own thread.